### PR TITLE
Made buttons in date picker non-highlightable

### DIFF
--- a/src/sass/global/_global.scss
+++ b/src/sass/global/_global.scss
@@ -17,6 +17,10 @@
     width: 300px;
     height: auto;
     margin: 10% auto;
+    -webkit-user-select: none;  /* Chrome all / Safari all */
+    -moz-user-select: none;     /* Firefox all */
+    -ms-user-select: none;      /* IE 10+ */
+    user-select: none;          /* Likely future */   
 }
 .mtp-picker {
     width: 100%;


### PR DESCRIPTION
I put some user-select:none code in the wrapper so the user can't accidentally highlight stuff