### PR TITLE
update minor notes in readme and remove ghpages from default task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# material-timepicker 
+# material-timepicker
 
 [![Build Status](https://strider.nickc.io/hownowbrowncow/material-timepicker/badge?branch=master)](https://strider.nickc.io/hownowbrowncow/material-timepicker) [![Dependency Status](https://david-dm.org/hownowbrowncow/material-timepicker.svg)](https://david-dm.org/hownowbrowncow/material-timepicker)
 
@@ -9,6 +9,15 @@ Available on NPM only
 ```
 npm install material-timepicker
 ```
+
+## Build
+
+Requires the use of the [gulp task runner](https://github.com/gulpjs/gulp). To install globally, use `npm install -g gulp`
+
+* **Build** - `gulp`
+* **Test** - `gulp test:js`
+* **Run Locally** - `npm start`
+
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ npm install material-timepicker
 
 ## Build
 
-Requires the use of the [gulp task runner](https://github.com/gulpjs/gulp). To install globally, use `npm install -g gulp`
+Requires the use of the [gulp task runner](https://github.com/gulpjs/gulp) and babel cli. To install globally, use `npm install -g gulp babel-cli`
 
 * **Build** - `gulp`
 * **Test** - `gulp test:js`
 * **Run Locally** - `npm start`
+* **Build module-ready version** - `gulp && npm run build`
 
 
 ## About

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -32,7 +32,7 @@ gulp.task('clean:ghpages', () => del(['./ghpages/scripts/*', './ghpages/styleshe
 gulp.task('clean:js', () => del(`${jsOpts.outPath}/*`));
 gulp.task('clean:sass', () => del(`${sassOpts.outPath}/*`));
 gulp.task('clean:test', () => del(`${testOpts.outPath}/*`));
-gulp.task('clean', ['clean:js', 'clean:sass', 'clean:test', 'clean:ghpages']);
+gulp.task('clean', ['clean:js', 'clean:sass', 'clean:test']);
 
 gulp.task('dist:app', ['compile:sass', 'compile:js'], () => {
     gulp.src('./build/js/timepicker.js').pipe(gulp.dest('./dist'));

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/js/timepicker.js",
   "scripts": {
     "test": "gulp test:js",
+    "build": "cp ./build/css/main.css ./dist/css/timepicker.css && babel ./src --out-dir ./dist",
     "start": "http-server -p 9001"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "material design timepicker",
   "main": "./dist/js/timepicker.js",
   "scripts": {
-    "test": "gulp test:unit",
-    "build": "cp ./build/css/timepicker.css ./dist/css && babel ./src --out-dir ./dist"
+    "test": "gulp test:js",
+    "start": "http-server -p 9001"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,7 @@
     "gulp": "^3.9.1",
     "gulp-modern-tasks": "^1.0.1",
     "gulp-rimraf": "^0.2.0",
+    "http-server": "^0.9.0",
     "mocha": "^3.0.2",
     "run-sequence": "^1.2.2",
     "sinon": "^1.17.5"


### PR DESCRIPTION
Allo, @hownowbrowncow, I love this project. Added a few updates to the docs so that others might be able to build/use more easily! 

I also ran into some issues where I'd run gulp and it'd run the `clean:ghpages` task and end up deleting the whole folder, resulting in a massive diff. I figured maybe we should leave that part out unless building it for the `gh-pages` branch.

Finally, I added a very simple `http-server` module for use when wanting to run it locally.

Obviously I am no expert myself, just wanting to contribute!